### PR TITLE
Pad the last XRPART*.XXF file to 32768 bytes, or XOSL won't load it.

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -154,6 +154,10 @@ finally
 		$process_split.WaitForExit();
 	}
 	[ref]$i = 0; Get-ChildItem -Path $([IO.Path]::GetFullPath([IO.Path]::Combine($((Get-Item $PSScriptRoot).Parent.FullName),'build'))) XRPART* | Rename-Item -NewName { '{0}{1:d2}{2}' -f "XRPART", $i.value++, ".XXF" };
+	$lastSeg = (Get-ChildItem .\XRPART*.XXF)[-1]
+	if ($lastSeg.Length -lt 32768) {
+		'X' * (32768 - $lastSeg.Length) | Out-File -Append -NoNewLine -Encoding ascii $lastSeg.FullName
+	}
 
 	#########################
 	# Cleaning up processes #


### PR DESCRIPTION
The last segment must be padded to 32768 bytes. If you have modified XOSL to accept a third segment < 32768 bytes, I must do  that too on my release. I kept the historical behavior of requiring all segments to be 32kB in size.